### PR TITLE
Update DebugProfile.entitlements

### DIFF
--- a/trelloappclone_flutter/lib/features/board/presentation/index.dart
+++ b/trelloappclone_flutter/lib/features/board/presentation/index.dart
@@ -67,7 +67,11 @@ class _BoardScreenState extends State<BoardScreen> with Service {
                   leading: IconButton(
                       onPressed: () {
                         setState(() {
-                          (show) ? show = false : showCard = false;
+                          nameController.clear();
+                          textEditingControllers[selectedList]!.clear();
+                          show = false; 
+                          showCard = false;
+                          showtheCard[selectedCard] = false;
                         });
                       },
                       icon: const Icon(Icons.close)),
@@ -97,6 +101,7 @@ class _BoardScreenState extends State<BoardScreen> with Service {
                                 name: textEditingControllers[selectedList]!
                                     .text,
                                 rank: trello.lstbrd[selectedList].cards!.length));
+                            textEditingControllers[selectedList]!.clear();
                             setState(() {
                               showCard = false;
                               showtheCard[selectedCard] = false;
@@ -156,7 +161,8 @@ class _BoardScreenState extends State<BoardScreen> with Service {
               arguments: CardDetailArguments(
                   trello.lstbrd[selectedList].cards![itemIndex!],
                   trello.selectedBoard,
-                  trello.lstbrd[selectedList]));
+                  trello.lstbrd[selectedList])).then((value) => 
+                    setState(() {}));
         },
         item: Card(
           child: Padding(

--- a/trelloappclone_flutter/lib/features/carddetails/presentation/index.dart
+++ b/trelloappclone_flutter/lib/features/carddetails/presentation/index.dart
@@ -43,7 +43,7 @@ class _CardDetailsState extends State<CardDetails> with Service {
                 },
                 icon: const Icon(Icons.close, size: 30),
               ),
-              title: const Text("New Item"),
+              title: const Text("Description"),
               actions: [
                   IconButton(
                     icon: const Icon(Icons.check),
@@ -76,10 +76,52 @@ class _CardDetailsState extends State<CardDetails> with Service {
                 icon: const Icon(Icons.close, size: 30),
               ),
               actions: [
-                  IconButton(
-                    icon: const Icon(Icons.more_vert),
-                    onPressed: () {},
+                  PopupMenuButton<Text>(
+                    itemBuilder: (context) {
+                      return [
+                        PopupMenuItem(
+                          onTap: () => WidgetsBinding?.instance
+                              ?.addPostFrameCallback((_) {
+                            showDialog<String>(
+                                context: context,
+                                builder: (BuildContext context) => AlertDialog(
+                                      title: const Text('Delete Card'),
+                                      content:
+                                          const Text('Are you sure you want to delete this card?'),
+                                      actions: <Widget>[
+                                        TextButton(
+                                          onPressed: () =>
+                                              Navigator.pop(context, 'Cancel'),
+                                          child: const Text('Cancel'),
+                                        ),
+                                        TextButton(
+                                          onPressed: () => {
+                                              deleteCard(args.crd),
+                                              // Remove popup
+                                              Navigator.pop(context, 'Delete'),                                              
+                                              // Go one view back
+                                              Navigator.pop(context, 'Delete'),
+                                          },
+                                          child: const Text('Delete'),
+                                        ),
+                                      ],
+                                    ));
+                          }),
+                          value: const Text("Delete Card"),
+                          child: const ListTile(
+                            leading: Icon(Icons.delete),
+                            title: Text(
+                              "Delete Card",
+                            ),
+                          ),
+                        ),
+                      ];
+                    },
                   )
+                  // IconButton(
+                  //   icon: const Icon(Icons.more_vert),
+                  //   onPressed: () {},
+                  // )
                 ]),
       body: SingleChildScrollView(
         child: Padding(

--- a/trelloappclone_flutter/lib/utils/service.dart
+++ b/trelloappclone_flutter/lib/utils/service.dart
@@ -306,6 +306,16 @@ mixin Service {
         description: "${trello.user.name} updated the card ${crd.name}");
   }
 
+  //delete card
+  Future<void> deleteCard(Cardlist crd) async {
+    await dataClient.card.deleteCard(crd);
+
+    createActivity(
+        card: crd.id,
+        workspaceId: crd.workspaceId,
+        description: "${trello.user.name} deleted the card ${crd.name}");
+  }
+
   Future<int> archiveCardsInList(Listboard list) async {
     return dataClient.listboard.archiveCardsInList(list);
   }

--- a/trelloappclone_flutter/macos/Runner/DebugProfile.entitlements
+++ b/trelloappclone_flutter/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/trelloappclone_powersync_client/lib/protocol/data_client.dart
+++ b/trelloappclone_powersync_client/lib/protocol/data_client.dart
@@ -222,6 +222,13 @@ class _CardlistRepository extends _Repository {
     return true;
   }
 
+  Future<bool> deleteCard(Cardlist cardlist) async {
+    await client
+        .getDBExecutor()
+        .execute('DELETE FROM card WHERE id = ?', [cardlist.id]);
+    return true;
+  }
+
   Future<List<Cardlist>> getCardsforList(String listId) async {
     final results = await client.getDBExecutor().execute('''
           SELECT * FROM card WHERE listId = ? AND archived = 0 ORDER BY rank ASC


### PR DESCRIPTION
This allows Flutter on macos to connect to supabase and powersync.

macOS needs you to request a specific entitlement in order to access the network. To do that open macos/Runner/DebugProfile.entitlements and add the following key-value pair.

<key>com.apple.security.network.client</key>
<true/>
Then do the same thing in macos/Runner/Release.entitlements.

You can read more about this in the [Desktop support for Flutter](https://docs.flutter.dev/development/platform-integration/macos/building#setting-up-entitlements) documentation.

The PR adds the ability to delete cards on boards and cleans up the card name being there after the save or cancel. 